### PR TITLE
Avoid conflict in the global namespace of Python by wrapping with class.

### DIFF
--- a/autoload/sourcekittendaemon.vim
+++ b/autoload/sourcekittendaemon.vim
@@ -22,6 +22,7 @@ function! s:LoadPythonScript()
   execute s:python_version . 'import sys'
   execute s:python_version . 'sys.path.append("' . s:plug . '")'
   execute s:pyfile_version . l:script
+  execute s:python_version . 'source_kitten_daemon_vim = SourceKittenDaemonVim()'
 endfunction
 
 function! s:GetByteOfLastDot()
@@ -48,7 +49,7 @@ function! sourcekittendaemon#Complete(findstart, base)
 
   update
   call s:LoadPythonScript()
-  execute "python main(prefix = '" . a:base
+  execute "python source_kitten_daemon_vim.complete(prefix = '" . a:base
         \ . "', path = '" . expand("%:p")
         \ . "', offset = " . s:GetByteOfLastDot() . ")"
   return s:result

--- a/pythonx/sourcekittendaemon.py
+++ b/pythonx/sourcekittendaemon.py
@@ -24,31 +24,31 @@ class SourceKittenDaemonVim(object):
 
     def complete(self, prefix, path, offset):
         try:
-            clazz = SourceKittenDaemonVim
+            cls = SourceKittenDaemonVim
             response = self.__daemon.complete(path, offset)
             completions = [
-                x for x in map(clazz.convert_to_completions, response)
+                x for x in map(cls.convert_to_completions, response)
                     if x and SourceKittenDaemonVim.matches(prefix, x)]
             vim.command('let s:result = ' + str(completions))
         except urllib2.HTTPError, error:
             vim.command("echoerr " + error)
 
     @classmethod
-    def convert_to_completions(clazz, response):
+    def convert_to_completions(cls, response):
         try:
             return {
-                "word": clazz.remove_tokens(str(response["sourcetext"])),
+                "word": cls.remove_tokens(str(response["sourcetext"])),
                 "abbr": str(response["name"]),
             }
         except KeyError:
             return None
 
     @classmethod
-    def remove_tokens(clazz, string):
-        return re.sub(clazz.__token_regex, "", string)
+    def remove_tokens(cls, string):
+        return re.sub(cls.__token_regex, "", string)
 
     @classmethod
-    def matches(clazz, prefix, dictionary):
+    def matches(cls, prefix, dictionary):
         if not prefix:
             return True
         word = dictionary["word"]


### PR DESCRIPTION
## Modifications
- I wrapped top-level functions with two classes: `SourceKittenDaemon` and `SourceKittenDaemonVim`.
- Make the names of methods sname-cased ([Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/#method-names-and-instance-variables.)).
## Reason

When Vim executes scripts with `:python` or `:pyfile`, these consume the global namespace.
Possibly they conflict names defined in other files called by another plugins.
So, I used name such as `SourceKittenDaemon`, which seems not to be used by others,  to split namespace.
## Alternative suggestion

I also submitted #2. It may be simpler than this modifications to import `sourcekittendaemon` module and call `sourcekittendaemon.main` or `sourcekittendaemon.complete` instead of just calling `main`.
